### PR TITLE
fix getFilenameMetaData with path module.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 var Rx = require('rx');
 var _ = require('lodash');
 var fs = require('fs');
+var Path = require('path');
 
 var Observable = Rx.Observable;
 var observableProto = Observable.prototype;
@@ -16,13 +17,12 @@ function setFullPath(a, b) { return a + '/' + b; }
 
 function getFilenameMetaData(path) {
 	
-	var slash = Math.max(path.lastIndexOf('/'), 0),
-		dot = path.lastIndexOf('.');
+	var extension = Path.extname(path);
 	
 	return {
-		extension: path.substring(dot),
-		name:      path.substring(slash, dot),
-		location:  path.substring(0, slash),
+		extension: Path.extname(path),
+		name:      Path.basename(path, extension),
+		location:  Path.dirname(path),
 		path:      path
 	}
 };
@@ -52,9 +52,6 @@ function expanddir(dir) {
 		})
 		.where(function(x) {
 			return x.stat;
-		})
-		.select(function(x) {
-			return x.stat.isFile() ? getFilenameMetaData(x.path) : x;
 		});
 };
 


### PR DESCRIPTION
## Sample data with expanddir

before merge this request

```
// directory
{ extension: './documents/foo/bar',
  name: 'bar',
  location: './documents/foo',
  path: './documents/foo/bar',
  stat: 
   { dev: 0,
     mode: 16822,
     nlink: 1,
     uid: 0,
     gid: 0,
     rdev: 0,
     ino: 0,
     size: 0,
     atime: Wed Mar 05 2014 15:24:32 GMT+0900,
     mtime: Wed Mar 05 2014 15:24:32 GMT+0900,
     ctime: Mon Mar 03 2014 18:11:33 GMT+0900 } }
// file
{ extension: '.md',
  name: '/readme',
  location: './documents/foo/bar',
  path: './documents/foo/bar/readme.md' }
```

after merge this request

```
// directory
{ extension: '',
  name: 'bar',
  location: './documents/foo',
  path: './documents/foo/bar',
  stat: 
   { dev: 0,
     mode: 16822,
     nlink: 1,
     uid: 0,
     gid: 0,
     rdev: 0,
     ino: 0,
     size: 0,
     atime: Wed Mar 05 2014 15:24:32 GMT+0900,
     mtime: Wed Mar 05 2014 15:24:32 GMT+0900,
     ctime: Mon Mar 03 2014 18:11:33 GMT+0900 } }
// file
{ extension: '.md',
  name: 'readme',
  location: './documents/foo/bar',
  path: './documents/foo/bar/readme.md',
  stat: 
   { dev: 0,
     mode: 33206,
     nlink: 1,
     uid: 0,
     gid: 0,
     rdev: 0,
     ino: 0,
     size: 1773,
     atime: Wed Mar 05 2014 14:20:35 GMT+0900,
     mtime: Wed Mar 05 2014 14:20:35 GMT+0900,
     ctime: Wed Mar 05 2014 14:19:51 GMT+0900} }
```
